### PR TITLE
Make macOS specific components buildable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	DYNAMIC = libcorange.so
 	STATIC = libcorange.a
 	CFLAGS += -fPIC
-	LFLAGS += -lGL
+	LFLAGS += -framework OpenGL
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/metaballs/Makefile
+++ b/demos/metaballs/Makefile
@@ -16,7 +16,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(DEMO)
-	LFLAGS= $(LIBS) -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_Mixer -lSDL2_Net -lOpenCL
+	LFLAGS= $(LIBS) -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_Mixer -lSDL2_Net -lOpenCL
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/noise/Makefile
+++ b/demos/noise/Makefile
@@ -12,7 +12,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(DEMO)
-	LFLAGS= -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS= -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/parallax/Makefile
+++ b/demos/parallax/Makefile
@@ -13,7 +13,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(APP)
-	LFLAGS=-L../../ -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS=-L../../ -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/particles/Makefile
+++ b/demos/particles/Makefile
@@ -13,7 +13,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(APP)
-	LFLAGS=-L../../ -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS=-L../../ -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/physics/Makefile
+++ b/demos/physics/Makefile
@@ -12,7 +12,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(APP)
-	LFLAGS=-L../../ -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS=-L../../ -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/platformer/Makefile
+++ b/demos/platformer/Makefile
@@ -16,7 +16,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(DEMO)
-	LFLAGS= -lcorange -lGL -lSDLmain -lSDL2
+	LFLAGS= -lcorange -framework OpenGL -lSDLmain -lSDL2
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/rendering/Makefile
+++ b/demos/rendering/Makefile
@@ -12,7 +12,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(DEMO)
-	LFLAGS= -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS= -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/scotland/Makefile
+++ b/demos/scotland/Makefile
@@ -12,7 +12,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(DEMO)
-	LFLAGS= -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS= -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/sea/Makefile
+++ b/demos/sea/Makefile
@@ -12,7 +12,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(DEMO)
-	LFLAGS= -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS= -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/teapot/Makefile
+++ b/demos/teapot/Makefile
@@ -12,7 +12,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(DEMO)
-	LFLAGS= -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS= -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/tessellation/Makefile
+++ b/demos/tessellation/Makefile
@@ -12,7 +12,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(DEMO)
-	LFLAGS= -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS= -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/demos/ui/Makefile
+++ b/demos/ui/Makefile
@@ -13,7 +13,7 @@ endif
 
 ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
 	OUT=$(APP)
-	LFLAGS=-L../../ -lcorange -lGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
+	LFLAGS=-L../../ -lcorange -framework OpenGL -lSDL2main -lSDL2 -lSDL2_net -lSDL2_mixer
 endif
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)

--- a/include/SDL2/SDL_local.h
+++ b/include/SDL2/SDL_local.h
@@ -112,7 +112,7 @@ typedef void (APIENTRY * GLPATCHPARAMETERFVFN)(GLenum pname, const GLfloat* valu
 
 typedef void (APIENTRY * GLBROKENEXTENSIONFN)();
 
-#ifndef __unix__
+#if !defined(__unix__) && !defined(__APPLE__)
   extern GLACTIVETEXTUREFN glActiveTexture;
   extern GLCOMPRESSEDTEXIMAGE2DFN glCompressedTexImage2D;
   extern GLTEXIMAGE3DFN glTexImage3D;


### PR DESCRIPTION
The `-framework OpenGL` should be preferred to `-lGL` on macOS right now.

Linux should also be able to make use of libunwind through LLVM's libunwind (distros should package it), but that means extra dependencies so just leave the libunwind based backtrace function to macOS only (libunwind is linked automatically).

The `src/assets/config.c` change is really dirty, but I'm not sure how to feel about the use of nested functions in the first place. They're just not supported on any other compiler other than gcc.