### PR TITLE
fixed typo in the triangle_difference_v() function

### DIFF
--- a/src/cengine.c
+++ b/src/cengine.c
@@ -3895,8 +3895,8 @@ float triangle_difference_u(vertex v1, vertex v2, vertex v3) {
 
 float triangle_difference_v(vertex v1, vertex v2, vertex v3) {
   float max = v1.uvs.y;
-  max = v2.uvs.x > max ? v2.uvs.y : max;
-  max = v3.uvs.x > max ? v3.uvs.y : max;
+  max = v2.uvs.y > max ? v2.uvs.y : max;
+  max = v3.uvs.y > max ? v3.uvs.y : max;
   
   float min = v1.uvs.y;
   min = v2.uvs.y < min ? v2.uvs.y : min;


### PR DESCRIPTION
For the "max" variable, ".x" was used when it should have been ".y".

Please let me know if you have any questions about this fix.