### PR TITLE
make sprintf buffers a global defined in cengine.c

### DIFF
--- a/include/cengine.h
+++ b/include/cengine.h
@@ -70,14 +70,14 @@ void warning_(const char*);
 void debug_(const char*);
 
 
-char error_buf[ERROR_BUFFER_SIZE];
-char error_str[ERROR_BUFFER_SIZE];
+extern char error_buf[ERROR_BUFFER_SIZE];
+extern char error_str[ERROR_BUFFER_SIZE];
 
-char warning_buf[WARNING_BUFFER_SIZE];
-char warning_str[WARNING_BUFFER_SIZE];
+extern char warning_buf[WARNING_BUFFER_SIZE];
+extern char warning_str[WARNING_BUFFER_SIZE];
 
-char debug_buf[DEBUG_BUFFER_SIZE];
-char debug_str[DEBUG_BUFFER_SIZE];
+extern char debug_buf[DEBUG_BUFFER_SIZE];
+extern char debug_str[DEBUG_BUFFER_SIZE];
 
 #define error(MSG, ...) { \
   snprintf(error_str,(ERROR_BUFFER_SIZE-1), "[ERROR] (%s:%s:%i) ", __FILE__, __func__, __LINE__); \

--- a/src/cengine.c
+++ b/src/cengine.c
@@ -1,5 +1,14 @@
 #include "cengine.h"
 
+char error_buf[ERROR_BUFFER_SIZE];
+char error_str[ERROR_BUFFER_SIZE];
+
+char warning_buf[WARNING_BUFFER_SIZE];
+char warning_str[WARNING_BUFFER_SIZE];
+
+char debug_buf[DEBUG_BUFFER_SIZE];
+char debug_str[DEBUG_BUFFER_SIZE];
+
 fpath P(const char* path) {
   fpath p;
   


### PR DESCRIPTION
Avoids linker errors on linux, fixes #76 